### PR TITLE
Adding Wolf-Rayet example

### DIFF
--- a/aesop/masking.py
+++ b/aesop/masking.py
@@ -56,4 +56,4 @@ def get_spectrum_mask(spectrum, cutoff=1.5, plot=False):
         plt.plot(spectrum.wavelength[mask], spectrum.flux[mask], label='masked')
         plt.legend()
 
-    return mask
+    return np.logical_not(mask)

--- a/aesop/spectra.py
+++ b/aesop/spectra.py
@@ -79,6 +79,7 @@ class Spectrum1D(object):
         self.time = time
         self.continuum_normalized = continuum_normalized
 
+<<<<<<< f52110a699ba51e494185b516010e7b118f2ffbe
     def flux_calibrate_parameters(self, flux_calibrated_spectrum, polynomial_order, plots=False):
         """
         Interpolate high-res spectrum to low-res flux calibrated spectrum, then fit
@@ -146,7 +147,7 @@ class Spectrum1D(object):
 
         return transformed_spectrum
 
-    def plot(self, ax=None, normed=False, flux_offset=0, **kwargs):
+    def plot(self, ax=None, **kwargs):
         """
         Plot the spectrum.
 
@@ -161,16 +162,7 @@ class Spectrum1D(object):
         if ax is None:
             ax = plt.gca()
 
-        flux_80th_percentile = np.percentile(self.masked_flux, 80)
-
-        if normed:
-            flux = self.masked_flux / flux_80th_percentile
-        else:
-            flux = self.masked_flux
-
-        ax.plot(self.masked_wavelength, flux + flux_offset, **kwargs)
-        #ax.set_xlim([self.masked_wavelength.value.min(),
-        #             self.masked_wavelength.value.max()])
+        ax.plot(self.masked_wavelength, self.masked_flux, **kwargs)
         ax.set(xlabel='Wavelength [{0}]'.format(self.wavelength_unit),
                ylabel='Flux')
         if self.name is not None:
@@ -179,14 +171,14 @@ class Spectrum1D(object):
     @property
     def masked_wavelength(self):
         if self.mask is not None:
-            return self.wavelength[self.mask]
+            return self.wavelength[np.logical_not(self.mask)]
         else:
             return self.wavelength
 
     @property
     def masked_flux(self):
         if self.mask is not None:
-            return self.flux[self.mask]
+            return self.flux[np.logical_not(self.mask)]
         else:
             return self.flux
 
@@ -278,6 +270,7 @@ class Spectrum1D(object):
             outliers |= self.flux.value < -0.5
 
         self.mask |= outliers
+
 
 
 class EchelleSpectrum(object):

--- a/aesop/spectra.py
+++ b/aesop/spectra.py
@@ -79,7 +79,6 @@ class Spectrum1D(object):
         self.time = time
         self.continuum_normalized = continuum_normalized
 
-<<<<<<< f52110a699ba51e494185b516010e7b118f2ffbe
     def flux_calibrate_parameters(self, flux_calibrated_spectrum, polynomial_order, plots=False):
         """
         Interpolate high-res spectrum to low-res flux calibrated spectrum, then fit

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -254,6 +254,8 @@ Wolf-Rayet star:
     >>> # Plot the concatenated 1D spectrum
     >>> spec1d = target_spectrum.to_Spectrum1D()
     >>> spec1d.plot()
+
+    >>> import matplotlib.pyplot as plt
     >>> plt.ylim([0, 3])
     >>> plt.xlim([3500, 10000])
     >>> plt.xlabel('Wavelength [Angstrom]')

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -255,13 +255,6 @@ Wolf-Rayet star:
     >>> spec1d = target_spectrum.to_Spectrum1D()
     >>> spec1d.plot()
 
-    >>> import matplotlib.pyplot as plt
-    >>> plt.ylim([0, 3])
-    >>> plt.xlim([3500, 10000])
-    >>> plt.xlabel('Wavelength [Angstrom]')
-    >>> plt.ylabel('Flux')
-    >>> plt.show()
-
 .. plot::
 
     from astropy.utils.data import download_file

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -112,7 +112,7 @@ function has been mostly removed:
 
     >>> target_spectrum.continuum_normalize_from_standard(standard_spectrum,
     ...                                                   polynomial_order=8)
-    >>> target_spectrum[73].plot()
+    >>> target_spectrum[73].plot() # doctest: +SKIP
 
 .. plot::
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -62,7 +62,7 @@ make a quick plot of the 73rd order of the target's echelle spectrum:
 .. code-block:: python
 
     order73 = target_spectrum[73]
-    order73.plot()
+    order73.plot() # doctest: +SKIP
 
 .. plot::
 
@@ -145,7 +145,7 @@ continuum normalization method,
 .. code-block:: python
 
     >>> target_spectrum.continuum_normalize_lstsq(polynomial_order=2)
-    >>> target_spectrum[73].plot()
+    >>> target_spectrum[73].plot() # doctest: +SKIP
 
 .. plot::
 
@@ -186,7 +186,7 @@ object:
     >>> print(spec1d)
     <Spectrum1D: 3561.8-10390.9 Angstrom>
 
-    >>> spec1d.plot()
+    >>> spec1d.plot() # doctest: +SKIP
 
 Of course, this plot is going to look a bit bonkers because there is a lot of
 noise in the extreme red and blue, cosmic rays here and there, and whopping
@@ -253,7 +253,7 @@ Wolf-Rayet star:
 
     >>> # Plot the concatenated 1D spectrum
     >>> spec1d = target_spectrum.to_Spectrum1D()
-    >>> spec1d.plot()
+    >>> spec1d.plot() # doctest: +SKIP
 
 .. plot::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,19 +7,58 @@
 aesop
 *****
 
-``aesop`` is a data reduction toolkit for spectra from the Astrophysical
-Research Consortium (ARC) 3.5 m Telescope at Apache Point Observatory (APO).
-You can view the
-`source code and submit issues via GitHub <https://github.com/bmorris3/aesop>`_.
+``aesop`` is a data reduction toolkit for echelle spectra from the `Astrophysical
+Research Consortium (ARC) 3.5 m Telescope Echelle Spectrograph (ARCES)
+<http://www.apo.nmsu.edu/arc35m/Instruments/ARCES/>`_ at Apache Point
+Observatory (APO). You can view the `source code and submit issues via GitHub
+<https://github.com/bmorris3/aesop>`_.
 
 .. toctree::
-   :maxdepth: 1 
+   :maxdepth: 1
    :caption: Contents:
 
    install
    iraf
    getting_started
    api
+
+
+What is ``aesop``?
+==================
+
+In the interest of reproducing established results, we choose not to
+re-implement the canonical IRAF reduction routine
+`ReduceARCES.cl <https://github.com/bmorris3/aesop/blob/master/data/ReduceARCES.cl>`_,
+and to limit ``aesop``'s functionality to processing after the aperture
+extraction and initial wavelength solution.
+
+The current version of ``aesop`` is useful for the following tasks:
+
+ - Managing and manipulating spectra with convenient data structures
+   (`~aesop.EchelleSpectrum`, `~aesop.Spectrum1D`)
+
+ - Removing radial velocities from echelle orders via cross-correlation with
+   PHOENIX model spectra
+
+ - Normalizing out the blaze-function in each echelle order given observations
+   of a spectroscopic standard
+
+ - Further normalizing each order for a flat continuum with robust least-squares
+
+ - Concatenating the spectra in each order, and taking the mean between adjacent
+   orders where they overlap, to produce a 1D spectrum from 3000-10000 Angstroms
+
+
+Typical Workflow
+================
+
+In general, ``aesop`` users will follow this procedure:
+
+ 1. Install ``aesop``
+ 2. Run the ``ReduceARCES.cl`` IRAF script to reduce your echelle spectra
+    (see :ref:`iraf`)
+ 3. Open the extracted 1D spectra for each spectral order with ``aesop`` (see
+    :ref:`getting_started`)
 
 
 Indices and tables


### PR DESCRIPTION
This PR adds a lot more examples to the docs, including: 

* continuum normalization (both methods)
* merging all echelle orders to a 1D spectrum
* reducing Wolf-Rayet spectrum with whopping emission
* better front-page explanations of what the package is for

It also corrects the `Spectrum1D.mask` attribute to work more like numpy are supposed to, where `True` corresponds to a masked value, and `False` corresponds to unmasked values.