### PR TITLE
Legacy specutils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test -V --remote-data'
         - CONDA_CHANNELS='astropy astropy-ci-extras conda-forge'
-        - CONDA_DEPENDENCIES='specutils astroquery matplotlib scipy'
+        - CONDA_DEPENDENCIES='astroquery matplotlib scipy'
         - EVENT_TYPE='pull_request push'
         - ASTROPY_USE_SYSTEM_PYTEST=1
 
@@ -62,12 +62,6 @@ matrix:
         - os: linux
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
-
-        - os: linux
-          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts
-
-        - os: linux
-          env: ASTROPY_VERSION=lts
 
         # Try numpy pre-release
         - os: linux

--- a/aesop/legacy_specutils/__init__.py
+++ b/aesop/legacy_specutils/__init__.py
@@ -1,0 +1,4 @@
+from .indexer import *
+from .readspec import *
+from .spectrum1d import *
+from .specwcs import *

--- a/aesop/legacy_specutils/indexer.py
+++ b/aesop/legacy_specutils/indexer.py
@@ -1,0 +1,119 @@
+from astropy.modeling import Model
+import math
+import numpy as np
+
+class Indexer(Model):
+    """
+    Indexer class provides an alternate slicing mechanism for WCS'es. As WCS'es
+    are defined for negative integers as well, this indexer class can be
+    initialized with negative indices. Unlike python slice objects, a
+    negative index is the same as a positive index. However, this is only true
+    for initialization. Once initialized, the indexer can be used like normal
+    python slicing, with negative index pointing to length - index.
+
+    Parameters
+    --------------
+    start: int
+        the start point of the indexer, can be any integer
+    stop: int
+        the point up to which (not including) the index is valid, can be any
+        integer
+    step: int, optional
+        the jump between two indices
+
+    Raises
+    -----------
+    ValueError
+        if step is given as zero
+    """
+    # start = Parameter()
+    # stop = Parameter()
+    # step = Parameter()
+    # length = Parameter()
+
+    def __init__(self, start, stop, step=1):
+        self._n_models = 1
+        # self.param_names = ["start", "stop", "step", "length"]
+        if step == 0:
+            raise ValueError("slice step cannot be zero")
+        self.start = start
+        self.stop = stop
+        self.step = step
+
+    def _parse_slice(self, slice):
+        """
+        Internal method to extract the start, stop and stop from the given slice
+        object
+        """
+        if slice.step == 0:
+            raise ValueError("slice step cannot be zero")
+        step = slice.step if slice.step is not None else 1
+        if step < 0:
+            default_start = self.length - 1
+            default_stop = -1
+        else:
+            default_start = 0
+            default_stop = self.length
+        start = slice.start if slice.start is not None else default_start
+        stop = slice.stop if slice.stop is not None else default_stop
+        if slice.start is not None:
+            start += self.length if start < 0 else 0
+            start = 0 if start < 0 else start
+            start = self.length - 1 if start >= self.length else start
+        if slice.stop is not None:
+            stop += self.length if stop < 0 else 0
+            stop = -1 if stop < 0 else stop
+            stop = self.length if stop > self.length else stop
+        return start, stop, step
+
+    def __getitem__(self, d_slice):
+        """
+        Applies a slice on top of the current slice object, returning a new
+        indexer with the modifications.
+        NOTE: This method does not modify the current indexer
+
+        Parameters
+        -----------
+        d_slice: slice object
+            The new slice object to be applied
+        """
+        d_start, d_stop, d_step = self._parse_slice(d_slice)
+        n_stop = self.start + d_stop * self.step
+        n_start = self.start + d_start * self.step
+        n_step = self.step * d_step
+        return Indexer(n_start, n_stop, n_step)
+
+    def __call__(self, indices=None):
+        """
+        Transforms the input indices to the correct indices represented by the
+        indexer, removes those indexes which are not in range (i.e. beyond, and
+        including self.stop)
+
+        Parameters
+        -----------
+        indices: numpy array
+            The indices to be shifted
+        """
+        if indices is None:
+            indices = np.arange(self.length)
+        return self.__class__.evaluate(indices, self.start,
+                                       self.stop, self.step)
+
+    @classmethod
+    def evaluate(cls, indices, start, stop, step):
+        n_indices = indices * step + start
+        if step > 0:
+            to_delete = np.where(n_indices >= stop)
+        else:
+            to_delete = np.where(n_indices <= stop)
+        n_indices = np.delete(n_indices, to_delete)
+        return n_indices
+
+    @property
+    def length(self):
+        if (self.start - self.stop) * self.step > 0:
+            # the index represents a null list
+            return 0
+        return int(math.ceil(
+            math.fabs((self.start - self.stop) * 1.0 / self.step)))
+

--- a/aesop/legacy_specutils/readspec.py
+++ b/aesop/legacy_specutils/readspec.py
@@ -1,0 +1,581 @@
+# a simple fits readers that puts a lot of emphasis on the specwcs
+import re
+from collections import OrderedDict
+
+import numpy as np
+from astropy import units as u
+from astropy.io import fits
+
+from . import specwcs
+from .spectrum1d import Spectrum1D
+
+wat_keyword_pattern = re.compile(
+    '([^=\s]*)\s*=\s*(([^\"\'\s]+)|([\"\'][^\"\']+[\"\']))\s*')
+
+
+# class Spectrum1D(object):
+#     """
+#     Simple 1D spectrum object; taken from `aesop`.
+#
+#     A ``Spectrum1D`` object can be used to describe one order of an echelle
+#     spectrum, for example.
+#
+#     If the spectrum is initialized with ``wavelength``s that are not strictly
+#     increasing, ``Spectrum1D`` will sort the ``wavelength``, ``flux`` and
+#     ``mask`` arrays so that ``wavelength`` is monotonically increasing.
+#     """
+#     @u.quantity_input(wavelength=u.Angstrom)
+#     def __init__(self, wavelength=None, flux=None, name=None, mask=None,
+#                  wcs=None, meta=dict(), time=None, continuum_normalized=None):
+#         """
+#         Parameters
+#         ----------
+#         wavelength : `~numpy.ndarray`
+#             Wavelengths
+#         flux : `~numpy.ndarray`
+#             Fluxes
+#         name : str (optional)
+#             Name for the spectrum
+#         mask : `~numpy.ndarray` (optional)
+#             Boolean mask of the same shape as ``flux``
+#         wcs : `~specutils.Spectrum1DLookupWCS` (optional)
+#             Store the WCS parameters
+#         meta : dict (optional)
+#             Metadata dictionary.
+#         continuum_normalized : bool (optional)
+#             Is this spectrum continuum normalized?
+#         """
+#
+#         # Are wavelengths stored in increasing order?
+#         wl_inc = np.all(np.diff(wavelength) > 0)
+#
+#         # If not, force them to be, to simplify linear interpolation later.
+#         if not wl_inc:
+#             wl_sort = np.argsort(wavelength)
+#             wavelength = wavelength[wl_sort]
+#             flux = flux[wl_sort]
+#             if mask is not None:
+#                 mask = mask[wl_sort]
+#
+#         self.wavelength = wavelength
+#         self.wavelength_unit = wavelength.unit
+#         self.flux = flux if hasattr(flux, 'unit') else u.Quantity(flux)
+#         self.name = name
+#         self.mask = mask
+#         self.wcs = wcs
+#         self.meta = meta
+#         self.time = time
+#         self.continuum_normalized = continuum_normalized
+#
+#     @classmethod
+#     def from_specutils(cls, spectrum1d, name=None, **kwargs):
+#         """
+#         Convert a `~specutils.Spectrum1D` object into our Spectrum1D object.
+#
+#         Parameters
+#         ----------
+#         spectrum1d : `~specutils.Spectrum1D`
+#             Input spectrum
+#         name : str
+#             Target/spectrum name
+#         """
+#         return cls(wavelength=spectrum1d.wavelength, flux=spectrum1d.flux,
+#                    mask=spectrum1d._mask, name=name, **kwargs)
+
+
+
+class FITSWCSError(Exception):
+    pass
+
+
+class FITSWCSSpectrum1DError(FITSWCSError):
+    pass
+
+
+class FITSWCSSpectrum1DUnitError(FITSWCSError):
+    pass
+
+
+#keywords as described in http://iraf.net/irafdocs/specwcs.php
+
+fits_wcs_spec_func_type = {1: 'chebyshev',
+                           2: 'legendre',
+                           3: 'cubicspline',
+                           4: 'linearspline',
+                           5: 'pixelcoordinatearray',
+                           6: 'sampledcoordinatearray'}
+
+wcs_attributes_function_parameters = {'chebyshev': ['order', 'pmin', 'pmax'],
+                                      'legendre': ['order', 'pmin', 'pmax'],
+                                      'linearspline': ['npieces', 'pmin',
+                                                       'pmax'],
+                                      'cubicspline': ['npieces', 'pmin', 'pmax']}
+
+wcs_attributes_general_keywords = OrderedDict(
+    [('aperture', int), ('beam', int), ('dispersion_type', int),
+     ('dispersion0', float), ('average_dispersion_delta', float),
+     ('no_valid_pixels', int), ('doppler_factor', float),
+     ('aperture_low', float), ('aperture_high', float)])
+
+wcs_attributes_function_keywords = OrderedDict(
+    [('weight', float), ('zero_point_offset', float), ('type', int),
+     ('order', int), ('pmin', float), ('pmax', float), ('npieces', int)])
+
+
+def _get_num_coefficients(function_dict):
+    """
+    Returns the number of coeffecients according to the IRAF fits format defined
+    here: http://iraf.net/irafdocs/specwcs.php
+    """
+    function_type = function_dict["type"]
+
+    if function_type in ["legendre", "chebyshev"]:
+        return function_dict["order"]
+    elif function_type == "linearspline":
+        return function_dict["npieces"] + 1
+    elif function_type == "cubicspline":
+        return function_dict["npieces"] + 3
+    else:
+        return 0
+
+
+def _parse_fits_units(fits_unit_string):
+    """
+    Parse FITS units - converting Angstroms to Angstrom and nanometers to nanometer
+
+    Parameters
+    ----------
+
+    fits_unit_string: str
+    """
+
+    if fits_unit_string.lower().strip() == 'angstroms':
+        fits_unit_string = 'Angstrom'
+    elif fits_unit_string.lower().strip() == 'nanometers':
+        fits_unit_string = 'nanometer'
+
+    return u.Unit(fits_unit_string)
+
+
+def _parse_multispec_dict(multispec_dict):
+    """
+    Parse dictionary that contains the multispec information in wcs attributes (WAT keywords; often WAT2_???).
+    each specN keywords has information as a string in the following format:
+    ap beam dtype w1 dw nw z aplow aphigh wt_i w0_i ftype_i [parameters] [coefficients]
+
+    Parameters
+    ----------
+
+        multispec_dict: dict-like object
+            e.g. multi_spec_dict = {'wtype':'multispec', spec1:'...', 'spec2':'...', ..., 'specN':'...'}
+
+    """
+
+    parsed_multispec_dict = OrderedDict()
+
+    for spec_key in multispec_dict:
+        if not spec_key.lower().startswith('spec'):
+            continue
+
+        single_spec_dict = OrderedDict()
+        spec_string = multispec_dict[spec_key].strip().split()
+        for key_name, key_dtype in wcs_attributes_general_keywords.items():
+            single_spec_dict[key_name] = key_dtype(spec_string.pop(0))
+        single_spec_dict['functions'] = []
+        while len(spec_string) > 0:
+            # There seems to be a function defined for this spectrum -
+            # checking that the dispersion type indicates that:
+            assert single_spec_dict['dispersion_type'] == 2
+
+            function_dict = {}
+            for key_name, key_dtype in wcs_attributes_function_keywords.items():
+                function_dict[key_name] = key_dtype(spec_string.pop(0))
+
+                #last of the general keywords
+                if key_name == 'type':
+                    function_dict['type'] = fits_wcs_spec_func_type[function_dict['type']]
+                    break
+
+            # different function types defined in
+            # http://iraf.net/irafdocs/specwcs.php -- see fits_wcs_spec_func_type
+
+            function_type = function_dict['type']
+            if function_type in wcs_attributes_function_parameters:
+                for key_name in wcs_attributes_function_parameters[function_type]:
+                    key_dtype = wcs_attributes_function_keywords[key_name]
+                    function_dict[key_name] = key_dtype(spec_string.pop(0))
+                num_coefficients = _get_num_coefficients(function_dict)
+                coefficients = spec_string[:num_coefficients]
+                function_dict['coefficients'] = list(map(float, coefficients))
+                spec_string = spec_string[num_coefficients:]
+            else:
+                raise NotImplementedError
+
+            single_spec_dict["functions"].append(function_dict)
+
+        parsed_multispec_dict[spec_key] = single_spec_dict
+
+    return parsed_multispec_dict
+
+
+class FITSWCSSpectrum(object):
+    """This class is designed to extract all known spectroscopic WCS keywords from a FITS keyword header.
+     The resulting keywords can then be validated (several keywords will encode the same information). Other keywords
+     come in pairs (e.g. CRVAL1, CRVAL2) and will be available as a list (e.g. `.affine_transform_dict['crval']`).
+     Several FITS readers make use of this object.
+
+    Parameters
+    ----------
+
+    fits_header: dict-like object (e.g. `~astropy.io.fits.Header`)
+        FITS Header to be read
+
+    """
+
+    def __init__(self, fits_header):
+        self.fits_header = fits.Header(fits_header)
+
+        self.naxis = self.fits_header['naxis']
+
+        self.shape = []
+
+        for i in range(self.naxis):
+            self.shape.append(self.fits_header['naxis{0:d}'.format(i + 1)])
+
+        try:
+            self.wcs_dim = self.fits_header['WCSDIM']
+        except KeyError:
+            self.wcs_dim = None
+
+        try:
+            self.global_wcs_attributes = self.read_wcs_attributes(0)
+        except FITSWCSError:
+            self.global_wcs_attributes = None
+
+        if self.wcs_dim is not None:
+            self.wcs_attributes = []
+            for axis in range(self.wcs_dim):
+                self.wcs_attributes.append(self.read_wcs_attributes(axis + 1))
+
+        self.affine_transform_dict, self.transform_matrix = self.read_affine_transforms()
+        self.units = self.read_wcs_units()
+
+
+    def read_affine_transforms(self, wcs_dim=None):
+
+        if wcs_dim is None:
+            if self.wcs_dim is None:
+                wcs_dim = self.fits_header['NAXIS']
+            else:
+                wcs_dim = self.wcs_dim
+
+        affine_transform_keywords = ('ctype', 'crpix', 'crval', 'cdelt')
+        affine_transform_dict = dict(
+            [(key, [None] * wcs_dim) for key in affine_transform_keywords])
+
+        for i in range(wcs_dim):
+            for key in affine_transform_dict:
+                affine_transform_dict[key][i] = self.fits_header.get(
+                    '{0:s}{1:d}'.format(key, i + 1))
+
+        transform_matrix = self.read_transform_matrix(wcs_dim, cdelt=
+        affine_transform_dict['cdelt'])
+
+        return affine_transform_dict, transform_matrix
+
+    def read_wcs_units(self, wcs_dim=None):
+
+        if wcs_dim is None:
+            if self.wcs_dim is None:
+                wcs_dim = self.fits_header['NAXIS']
+            else:
+                wcs_dim = self.wcs_dim
+
+        units = [None] * wcs_dim
+
+        for i in range(wcs_dim):
+            try:
+                cunit_string = self.fits_header['cunit{0:d}'.format(i + 1)]
+            except KeyError:
+                continue
+
+            if cunit_string.strip().lower() == 'angstroms':
+                units[i] = u.AA
+            else:
+                units[i] = u.Unit(cunit_string)
+
+        return units
+
+
+    def read_transform_matrix(self, matrix_dim, cdelt=None):
+        if len(self.fits_header['cd?_?']) > 0:
+            if matrix_dim is None:
+                if self.wcs_dim is None:
+                    matrix_dim = self.fits_header['NAXIS']
+                else:
+                    matrix_dim = self.wcs_dim
+
+            transform_matrix = np.matrix(np.zeros((matrix_dim, matrix_dim)))
+            matrix_element_keyword_pattern = re.compile('cd(\d)_(\d)',
+                                                        re.IGNORECASE)
+            for matrix_element_keyword in self.fits_header['cd?_?']:
+                i, j = map(int, matrix_element_keyword_pattern.match(
+                    matrix_element_keyword).groups())
+                transform_matrix[j - 1, i - 1] = self.fits_header[
+                    matrix_element_keyword]
+            if cdelt is not None:
+                for i in range(matrix_dim):
+                    if cdelt[i] is not None:
+                        np.testing.assert_almost_equal(cdelt[i],
+                                                       transform_matrix[i, i])
+
+            return transform_matrix
+
+        else:
+            return None
+
+
+    def read_wcs_attributes(self, axis):
+        """
+        Reading WCS attribute information in WAT0_001-like keywords
+
+        Parameters
+        ----------
+
+        axis: int
+            specifying which axis to read (e.g axis=2 will read WAT2_???).
+        """
+
+        wcs_attributes = self.fits_header['wat{0:d}_???'.format(axis)]
+        if len(wcs_attributes) == 0:
+            raise FITSWCSError
+
+        raw_wcs_attributes = ''.join([wcs_attributes[key].ljust(68) for key in
+                                      sorted(wcs_attributes.keys())])
+
+        wat_dictionary = OrderedDict()
+        for wat_keyword_match in wat_keyword_pattern.finditer(
+                raw_wcs_attributes):
+            wat_dictionary[wat_keyword_match.groups()[0]] = \
+                wat_keyword_match.groups()[1].strip('\"\'')
+
+        if 'units' in wat_dictionary:
+            wat_dictionary['units'] = _parse_fits_units(wat_dictionary['units'])
+
+        return wat_dictionary
+
+def multispec_wcs_reader(wcs_info, dispersion_unit=None):
+    """Extracting multispec information out of WAT header keywords and
+    building WCS with it
+
+    Parameters
+    ----------
+
+    dispersion_unit : astropy.unit.Unit, optional
+        specify a unit for the dispersion if none exists or overwrite,
+        default=None
+    """
+
+    assert wcs_info.global_wcs_attributes['system'] == 'multispec'
+    assert wcs_info.wcs_attributes[1]['wtype'] == 'multispec'
+
+    if dispersion_unit is None:
+        dispersion_unit = wcs_info.wcs_attributes[0]['units']
+
+    multispec_dict = _parse_multispec_dict(wcs_info.wcs_attributes[1])
+    wcs_dict = OrderedDict()
+    for spec_key in multispec_dict:
+        single_spec_dict = multispec_dict[spec_key]
+        if single_spec_dict['dispersion_type'] == 1:
+            #log-linear dispersion
+            log = True
+        else:
+            log = False
+
+        if single_spec_dict['dispersion_type'] in [0, 1]:
+            #linear or log-linear dispersion
+            dispersion_wcs = specwcs.Spectrum1DPolynomialWCS(
+                degree=1, c0=single_spec_dict["dispersion0"],
+                c1=single_spec_dict["average_dispersion_delta"])
+
+        else:
+            # single_spec_dict['dispersion_type'] == 2
+            dispersion_wcs = specwcs.WeightedCombinationWCS()
+            for function_dict in single_spec_dict["functions"]:
+                if function_dict['type'] == 'legendre':
+                    ##### @embray can you figure out if that's the only way to
+                    ##  instantiate a polynomial (with c0=xx, c1=xx, ...)?
+
+                    coefficients = dict([('c{:d}'.format(i),
+                                        function_dict['coefficients'][i])
+                                        for i in range(function_dict['order'])])
+
+                    wcs = specwcs.Spectrum1DIRAFLegendreWCS(
+                        function_dict['order'], function_dict['pmin'],
+                        function_dict['pmax'], **coefficients)
+
+                elif function_dict['type'] == 'chebyshev':
+                    coefficients = dict([('c{:d}'.format(i),
+                                        function_dict['coefficients'][i])
+                                        for i in range(function_dict['order'])])
+
+                    wcs = specwcs.Spectrum1DIRAFChebyshevWCS(
+                        function_dict['order'], function_dict['pmin'],
+                        function_dict['pmax'], **coefficients)
+
+                elif function_dict['type'] in ['linearspline', 'cubicspline']:
+                    if function_dict['type'] == 'linearspline':
+                        degree = 1
+                    else:
+                        degree = 3
+                    n_pieces = function_dict['npieces']
+                    pmin = function_dict['pmin']
+                    pmax = function_dict['pmax']
+                    y = [function_dict['coefficients'][i]
+                         for i in range(n_pieces + degree)]
+                    wcs = specwcs.Spectrum1DIRAFBSplineWCS(degree, n_pieces, y,
+                                                           pmin, pmax)
+                else:
+                    raise NotImplementedError
+                dispersion_wcs.add_WCS(
+                    wcs, weight=function_dict["weight"],
+                    zero_point_offset=function_dict["zero_point_offset"])
+
+        composite_wcs = specwcs.MultispecIRAFCompositeWCS(
+            dispersion_wcs, single_spec_dict["no_valid_pixels"],
+            z=single_spec_dict["doppler_factor"], log=log,
+            aperture=single_spec_dict["aperture"], beam=single_spec_dict["beam"]
+            , aperture_low=single_spec_dict["aperture_low"],
+            aperture_high=single_spec_dict["aperture_high"],
+            unit=dispersion_unit)
+        wcs_dict[spec_key] = composite_wcs
+    return wcs_dict
+
+
+def read_fits_wcs_linear1d(wcs_info, dispersion_unit=None, spectral_axis=0):
+    """Read very a very simple 1D WCS mainly comprising of CRVAL, CRPIX, ...
+    from a FITS WCS Information container
+
+    Parameters
+    ----------
+
+    fits_wcs_information : ~specutils.io.read_fits.FITSWCSSpectrum
+        object compiling WCS information to be used in these readers
+
+    .. TODO: Examine this further.
+
+    """
+
+    # for the 1D reader setting the spectral_axis to anything else than 0 seems
+    # to be strange;
+    # actually, it's perfectly reasonable IF you want to extract
+    # information from, say, a data cube and you're only interested in the
+    # spectral dimension.  This tool can easily be used for that purpose.
+
+    dispersion_unit = dispersion_unit
+
+    dispersion_delta = None
+    if wcs_info.transform_matrix is not None:
+        dispersion_delta = wcs_info.transform_matrix[spectral_axis, spectral_axis]
+
+    if wcs_info.affine_transform_dict['cdelt'][spectral_axis] is not None:
+        #checking that both cd1_1 and cdelt1 are either the same or
+        # one of them non-existent
+        if dispersion_delta is not None:
+            np.testing.assert_almost_equal(
+                dispersion_delta,
+                wcs_info.affine_transform_dict['cdelt'][spectral_axis])
+        dispersion_delta = wcs_info.affine_transform_dict['cdelt'][spectral_axis]
+
+    if dispersion_delta is None:
+        raise FITSWCSSpectrum1DError
+
+    if wcs_info.affine_transform_dict['crval'][spectral_axis] is None:
+        raise FITSWCSSpectrum1DError
+    else:
+        dispersion_start = wcs_info.affine_transform_dict['crval'][spectral_axis]
+
+    pixel_offset = wcs_info.affine_transform_dict['crpix'][spectral_axis] or 1
+    pixel_offset -= 1
+
+    dispersion_unit = wcs_info.units[spectral_axis] or dispersion_unit
+
+    if None in [dispersion_start, dispersion_delta, pixel_offset]:
+        raise FITSWCSSpectrum1DError
+    dispersion_start += -pixel_offset * dispersion_delta
+    return specwcs.Spectrum1DPolynomialWCS(degree=1, unit=dispersion_unit,
+                                           c0=dispersion_start,
+                                           c1=dispersion_delta)
+
+
+def read_fits_spectrum1d(filename, dispersion_unit=None, flux_unit=None):
+    """
+    1D reader for spectra in FITS format. This function determines what format
+    the FITS file is in, and attempts to read the Spectrum. This reader just
+    uses the primary extension in a FITS file and reads the data and header from
+    that. It will return a Spectrum1D object if the data is linear, or a list of
+    Spectrum1D objects if the data format is multi-spec
+
+    Parameters
+    ----------
+
+    filename : str
+        FITS filename
+
+    dispersion_unit : ~astropy.unit.Unit, optional
+        unit of the dispersion axis - will overwrite possible information given
+        in the FITS keywords
+        default = None
+
+    flux_unit : ~astropy.unit.Unit, optional
+        unit of the flux
+
+    Raises
+    --------
+    NotImplementedError
+        If the format can't be read currently
+    """
+    if dispersion_unit:
+        dispersion_unit = u.Unit(dispersion_unit)
+
+    data = fits.getdata(filename)
+    header = fits.getheader(filename)
+
+    wcs_info = FITSWCSSpectrum(header)
+
+    if wcs_info.naxis == 1:
+        wcs = read_fits_wcs_linear1d(wcs_info, dispersion_unit=dispersion_unit)
+        return Spectrum1D(data, wcs=wcs)
+    elif wcs_info.naxis == 2 and \
+            wcs_info.affine_transform_dict['ctype'] == ["MULTISPE", "MULTISPE"]:
+        multi_wcs = multispec_wcs_reader(wcs_info, dispersion_unit=dispersion_unit)
+        multispec = []
+        for spectrum_data, spectrum_wcs in zip(data, multi_wcs.values()):
+            multispec.append(
+                Spectrum1D(spectrum_data, wcs=spectrum_wcs))
+        return multispec
+
+    elif wcs_info.naxis == 3 and \
+            wcs_info.affine_transform_dict['ctype'] == ["LINEAR","LINEAR","LINEAR"]:
+        wcs = read_fits_wcs_linear1d(wcs_info, dispersion_unit=dispersion_unit)
+        equispec = []
+        for i in range(data.shape[0]):
+            equispec.append(
+                Spectrum1D(data[i][0], wcs=wcs))
+        return equispec
+
+    elif wcs_info.naxis == 3 and \
+            wcs_info.affine_transform_dict['ctype'] == ["MULTISPE", "MULTISPE","LINEAR"]:
+        multi_wcs = multispec_wcs_reader(wcs_info, dispersion_unit=dispersion_unit)
+        multispec = []
+        for j in range(data.shape[1]):
+            equispec = []
+            for i in range(data.shape[0]):
+                equispec.append(
+                    Spectrum1D(data[i][j], wcs=list(multi_wcs.values())[j]))
+            multispec.append(equispec)
+        return multispec
+
+    else:
+        raise NotImplementedError("Either the FITS file does not represent a 1D"
+                                  " spectrum or the format isn't supported yet")

--- a/aesop/legacy_specutils/spectrum1d.py
+++ b/aesop/legacy_specutils/spectrum1d.py
@@ -1,0 +1,404 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# This module implements the Spectrum1D class.
+
+from __future__ import print_function, division
+from .indexer import Indexer
+
+__all__ = ['Spectrum1D']
+
+import copy
+from astropy import log
+from astropy.nddata import NDData
+
+from astropy import units as u
+
+import numpy as np
+
+
+class Spectrum1D(NDData):
+    """A subclass of `NDData` for a one dimensional spectrum in Astropy.
+
+    This class inherits all the base class functionality from the NDData class
+    and is communicative with other Spectrum1D objects in ways which make sense.
+
+    Parameters
+    ----------
+    data : `~numpy.ndarray`
+        flux of the spectrum
+
+    wcs : `spectrum1d.wcs.specwcs.BaseSpectrum1DWCS`-subclass
+        transformation between pixel coordinates and "dispersion" coordinates
+        this carries the unit of the dispersion
+
+    unit : `~astropy.unit.Unit` or None, optional
+        unit of the flux, default=None
+
+    mask : `~numpy.ndarray`, optional
+        Mask for the data, given as a boolean Numpy array with a shape
+        matching that of the data. The values must be ``False`` where
+        the data is *valid* and ``True`` when it is not (like Numpy
+        masked arrays). If `data` is a numpy masked array, providing
+        `mask` here will causes the mask from the masked array to be
+        ignored.
+
+    meta : `dict`-like object, optional
+        Metadata for this object.  "Metadata" here means all information that
+        is included with this object but not part of any other attribute
+        of this particular object.  e.g., creation date, unique identifier,
+        simulation parameters, exposure time, telescope name, etc.
+
+    """
+
+    _wcs_attributes = {'wavelength': {'unit': u.m},
+                      'frequency': {'unit': u.Hz},
+                      'energy': {'unit': u.J},
+                      'velocity': {'unit': u.m/u.s}}
+
+    @classmethod
+    def from_array(cls, dispersion, flux, dispersion_unit=None,
+                   uncertainty=None, mask=None, meta=None, copy=True,
+                   unit=None):
+        """Initialize `Spectrum1D`-object from two `numpy.ndarray` objects
+
+        Parameters:
+        -----------
+        dispersion : `~astropy.units.quantity.Quantity` or `~np.array`
+            The dispersion for the Spectrum (e.g. an array of wavelength
+            points). If an array is specified `dispersion_unit` needs to be a spectral unit
+
+        flux : `~astropy.units.quantity.Quantity` or `~np.array`
+            The flux level for each wavelength point. Should have the same length
+            as `dispersion`.
+
+        dispersion_unit :
+        error : `~astropy.nddata.NDError`, optional
+            Errors on the data.
+
+        mask : `~numpy.ndarray`, optional
+            Mask for the data, given as a boolean Numpy array with a shape
+            matching that of the data. The values should be ``False`` where the
+            data is *valid* and ``True`` when it is not (as for Numpy masked
+            arrays).
+
+        meta : `dict`-like object, optional
+            Metadata for this object. "Metadata here means all information that
+            is included with this object but not part of any other attribute
+            of this particular object. e.g., creation date, unique identifier,
+            simulation parameters, exposure time, telescope name, etc.
+
+        copy : bool, optional
+            If True, the array will be *copied* from the provided `data`,
+            otherwise it will be referenced if possible (see `numpy.array` :attr:`copy`
+            argument for details).
+
+        Raises
+        ------
+        ValueError
+            If the `dispersion` and `flux` arrays cannot be broadcast (e.g. their shapes
+            do not match), or the input arrays are not one dimensional.
+
+        """
+
+        if dispersion.ndim != 1 or dispersion.shape != flux.shape:
+            raise ValueError("dispersion and flux need to be one-dimensional "
+                             "Numpy arrays with the same shape")
+
+        if hasattr(dispersion, 'unit'):
+            if dispersion_unit is not None:
+                dispersion = dispersion.to(dispersion_unit).value
+            else:
+                dispersion_unit = dispersion.unit
+                dispersion = dispersion.value
+
+
+        spec_wcs = Spectrum1DLookupWCS(dispersion, unit=dispersion_unit)
+
+        if copy:
+            flux = flux.copy()
+
+        return cls(flux=flux, wcs=spec_wcs, unit=unit, uncertainty=uncertainty,
+                   mask=mask, meta=meta)
+
+    @classmethod
+    def from_table(cls, table, dispersion_column='dispersion',
+                   flux_column='flux', uncertainty_column=None,
+                   flag_columns=None):
+        """
+        Initializes a `Spectrum1D`-object from an `~astropy.table.Table` object
+
+        Parameters
+        ----------
+
+        table : ~astropy.table.Table object
+
+        dispersion_column : str, optional
+            name of the dispersion column. default is 'dispersion'
+
+        flux_column : str, optional
+            name of the flux column. default is 'flux'
+
+        uncertainty_column : str, optional
+            name of the uncertainty column. If set to None uncertainty is set to None. default is None
+
+        flag_columns : str or list, optional
+            name or names of flag columns. If multiple names are supplied a ~astropy.nddata.FlagCollection will be built.
+            default is None
+        """
+
+        flux = table[flux_column]
+        dispersion = table[dispersion_column]
+
+        if uncertainty_column is not None:
+            uncertainty = table[uncertainty_column]
+            if uncertainty.unit != flux.unit:
+                log.warning('"uncertainty"-column and "flux"-column do not share the units (%s vs %s) ',
+                            uncertainty.unit, flux.unit)
+        else:
+            uncertainty = None
+
+        return cls.from_array(flux=flux.data, dispersion=dispersion.data,
+                              uncertainty=uncertainty, dispersion_unit=dispersion.units,
+                              unit=flux.units, mask=table.mask, meta=table.meta)
+
+
+
+    @classmethod
+    def from_ascii(cls, filename, uncertainty=None, mask=None, dtype=np.float, comments='#',
+                   delimiter=None, converters=None, skiprows=0,
+                   usecols=None):
+        raw_data = np.loadtxt(filename, dtype=dtype, comments=comments,
+                              delimiter=delimiter, converters=converters,
+                              skiprows=skiprows, usecols=usecols, ndmin=2)
+
+        if raw_data.shape[1] != 2:
+            raise ValueError('data contained in filename must have exactly two columns')
+
+        return cls.from_array(dispersion=raw_data[:,0], flux=raw_data[:,1], uncertainty=uncertainty, mask=mask)
+
+    @classmethod
+    def from_fits(cls, filename):
+        """
+        This function is a dummy function and will fail for now. Please use the functions provided in
+        `~specutils.io.read_fits` for this task.
+        """
+
+        raise NotImplementedError('This function is not implemented. To read FITS files please refer to the'
+                                  ' documentation')
+
+    def __init__(self, flux, wcs, unit=None, uncertainty=None, mask=None,
+                 meta=None, indexer=None, *args, **kwargs):
+
+        super(Spectrum1D, self).__init__(data=flux, unit=unit, wcs=wcs, uncertainty=uncertainty,
+                   mask=mask, meta=meta, *args, **kwargs)
+
+        self._wcs_attributes = copy.deepcopy(self.__class__._wcs_attributes)
+        if indexer is None:
+            self.indexer = Indexer(0, len(flux))
+        else:
+            self.indexer = indexer
+        for key in list(self._wcs_attributes):
+
+            wcs_attribute_unit = self._wcs_attributes[key]['unit']
+
+            try:
+                unit_equivalent = wcs_attribute_unit.is_equivalent(self.wcs.unit, equivalencies=self.wcs.equivalencies)
+            except TypeError:
+                unit_equivalent = False
+
+
+            if not unit_equivalent:
+                #if unit is not convertible to wcs attribute - delete that wcs attribute
+                del self._wcs_attributes[key]
+                continue
+
+            if wcs_attribute_unit.physical_type == self.wcs.unit.physical_type:
+                self._wcs_attributes[key]['unit'] = self.wcs.unit
+
+
+    def flux_getter(self):
+        #returning the flux
+        return u.Quantity(self.data, self.unit, copy=False)
+
+    def flux_setter(self, flux):
+        if hasattr(flux, 'unit'):
+            if self.unit is not None:
+                flux = flux.to(self.unit).value
+            else:
+                raise ValueError('Attempting to set a new unit for this object'
+                                 'this is not allowed by Spectrum1D')
+
+        self._data = flux
+
+
+    flux = property(flux_getter, flux_setter)
+
+    def __getattr__(self, name):
+        if name in self._wcs_attributes:
+            return self.dispersion.to(self._wcs_attributes[name]['unit'], equivalencies=self.wcs.equivalencies)
+        elif name[:-5] in self._wcs_attributes and name[-5:] == '_unit':
+            return self._wcs_attributes[name[:-5]]['unit']
+        else:
+            super(Spectrum1D, self).__getattribute__(name)
+
+
+    def __setattr__(self, name, value):
+        if name[:-5] in self._wcs_attributes and name[-5:] == '_unit':
+            self._wcs_attributes[name[:-5]]['unit'] = u.Unit(value)
+        else:
+            super(Spectrum1D, self).__setattr__(name, value)
+
+    def __dir__(self):
+        return list(self.__dict__.keys()) + list(self._wcs_attributes.keys()) + \
+               [item + '_unit' for item in self._wcs_attributes.keys()]
+
+
+
+
+    #TODO: let the WCS handle what to do with len(flux)
+    @property
+    def dispersion(self):
+        #returning the disp
+        pixel_indices = np.arange(len(self.flux))
+        return self.wcs(self.indexer(pixel_indices))
+
+    @property
+    def dispersion_unit(self):
+        return self.wcs.unit
+
+
+    def interpolate(self, new_dispersion, kind='linear', bounds_error=True, fill_value=np.nan):
+        """Interpolates onto a new wavelength grid and returns a new `Spectrum1D`-object.
+
+        Parameters
+        ----------
+        new_dispersion : `~numpy.ndarray`
+            The dispersion array to interpolate the flux on to.
+
+        kind : `str` or `int`, optional
+            Specifies the kind of interpolation as a string
+            ('linear', 'nearest', 'zero', 'slinear', 'quadratic', 'cubic')
+            or as an integer specifying the order of the spline interpolator
+            to use. Default is 'linear'.
+
+        bounds_error : `bool`, optional
+            If True, an error is thrown any time interpolation is attempted on a
+            dispersion point outside of the range of the original dispersion map
+            (where extrapolation is necessary). If False, out of bounds values
+            are assigned `fill_value`. By default, an error is raised.
+
+        fill_value : `float`, optional
+            If provided, then this value will be used to fill in for requested
+            dispersion points outside of the original dispersion map. If not
+            provided, then the default is NaN.
+
+        Raises
+        ------
+        ImportError
+            If the `SciPy interpolate interp1d <http://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html>`_
+            function cannot be imported.
+
+        Notes
+        -----
+        When the `Spectrum1D` class has an associated error array, the nearest
+        uncertainty is taken for each new dispersion point.
+
+        """
+
+        # Check for SciPy availability
+
+
+        if kind != 'linear':
+            raise ValueError('No other kind but linear supported')
+
+        if not isinstance(new_dispersion, BaseSpectrum1DWCS):
+            new_dispersion = Spectrum1DLookupWCS(np.array(new_dispersion))
+
+
+        new_pixel = self.wcs.invert(new_dispersion.lookup_table)
+
+        new_flux = np.interp(new_pixel, self.wcs.pixel_index, self.flux, left=np.nan, right=np.nan)
+
+
+        return self.__class__(new_flux, wcs=new_dispersion, meta=self.meta)
+
+
+    def slice_dispersion(self, start=None, stop=None):
+        """Slice the spectrum within a given start and end dispersion value.
+
+        Parameters
+        ----------
+        start : `float`
+            Starting slice point.
+        stop : `float`
+            Stopping slice point.
+
+        Notes
+        -----
+        Often it is useful to slice out a portion of a `Spectrum1D` objects
+        either by two dispersion points (e.g. two wavelengths) or by the indices
+        of the dispersion/flux arrays (see :meth:`~Spectrum1D.slice_index` for this
+        functionality).
+
+        See Also
+        --------
+        See `~Spectrum1D.slice_index`
+        """
+        raise NotImplementedError('Waiting for slicing implementation in WCS and NDData')
+        # Transform the dispersion end points to index space
+        start_index, stop_index = self.wcs([start, stop])
+
+        #return self.slice_index(start_index, stop_index)
+
+
+    def slice_index(self, start=None, stop=None, step=None):
+        """Slice the spectrum within a given start and end index.
+
+        Parameters
+        ----------
+        start : int
+            Starting slice point.
+        stop : int
+            Stopping slice point.
+        step : int
+            Slice step
+        Notes
+        -----
+        Often it is useful to slice out a portion of a `Spectrum1D` objects
+        either by two index points (see :meth:`~Spectrum1D.slice_dispersion`) or by
+        the indices of the dispersion/flux array.
+
+        See Also
+        --------
+        See `~Spectrum1D.slice_dispersion`
+        """
+
+        # We need to slice the following items:
+        # >> disp, flux, error, and mask
+        # Which are all common NDData objects, therefore I am (perhaps
+        # reasonably) assuming that __slice__ will be a NDData base function
+        # which we will inherit.
+        # At this time, that function raises an error if WCS is not None, so it
+        # cannot be used
+        item = slice(start, stop, step)
+        new_data = self.data[item]
+
+        if self.uncertainty is not None:
+            new_uncertainty = self.uncertainty[item]
+        else:
+            new_uncertainty = None
+
+        if self.mask is not None:
+            new_mask = self.mask[item]
+            # mask setter expects an array, always
+            if new_mask.shape == ():
+                new_mask = np.array(new_mask)
+        else:
+            new_mask = None
+
+        new_indexer = self.indexer.__getitem__(item)
+        new_wcs = self.wcs
+
+        return self.__class__(new_data, new_wcs, meta=self.meta, unit=self.unit
+                              , uncertainty=new_uncertainty, mask=new_mask,
+                              indexer=new_indexer)
+

--- a/aesop/legacy_specutils/specwcs.py
+++ b/aesop/legacy_specutils/specwcs.py
@@ -1,0 +1,688 @@
+# This module provides a basic and probably temporary WCS solution until astropy has a wcs built-in
+
+import warnings
+import numpy as np
+
+from astropy.modeling import polynomial
+import astropy.units as u
+
+from astropy import constants
+import math
+
+
+##### Delete at earliest convenience (currently deprecated)
+#### VVVVVVVVVV
+valid_spectral_units = [u.pix, u.km / u.s, u.m, u.Hz, u.erg]
+
+from astropy.modeling import Model, Parameter
+
+
+class BSplineModel(Model):
+    """
+    Implements a BSpline representation of 1-D curve.
+
+    Parameters
+    -----------
+    degree : int
+        the degree of the spline (e.g. 1 for linear, 3 for cubic)
+    knots : array_like
+        array of knots of the spline
+    coefficients: array_like
+        coefficients corresponding to the knots, should be
+        the same length as knots
+
+    Raises
+    --------
+    ValueError
+        If the length of knots and coefficients arrays do not match
+    """
+
+    @classmethod
+    def from_data(cls, x, y, degree):
+        """
+        Initializes the B-spline representation of 1-D curve.
+        Given the set of data points (x[i], y[i]) determines a smooth spline
+        approximation
+        Parameters
+        -----------
+        x, y : array_like
+            The data points defining a curve y = f(x)
+        degree: int
+            the degree of the spline (e.g. 1 for linear, 3 for cubic)
+        """
+        from scipy.interpolate import splrep
+
+        knots, coefficients, _ = splrep(x, y, k=degree)
+        return cls(degree, knots, coefficients)
+
+    def __init__(self, degree, knots, coefficients):
+
+        if len(knots) != len(coefficients):
+            raise ValueError("Number of knots ({0}) have to be equal to the"
+                             "number of coefficients ({1})"
+                             .format(len(knots), len(coefficients)))
+        # TODO: Scipy does not raise any error in any case, figure out why
+        # if len(knots) - degree - 1 <= 1:
+        #     raise ValueError("Not enough knots ({0})".format(len(knots)))
+
+        self.degree = degree
+        self.num_params = len(knots)
+        self.param_names = self._generate_param_names(self.num_params)
+
+        params = {}
+        for i in range(len(knots)):
+            params["c{:d}".format(i)] = coefficients[i]
+            params["t{:d}".format(i)] = knots[i]
+        super(BSplineModel, self).__init__(**params)
+
+    def _generate_param_names(self, n_pieces):
+        names = []
+        for i in range(n_pieces):
+            names.append("c{:d}".format(i))
+            names.append("t{:d}".format(i))
+        return names
+
+    @classmethod
+    def evaluate(cls, input, degree, knots, coefficients):
+        from scipy.interpolate import splev
+
+        return splev(input, (knots, coefficients, degree))
+
+    def __call__(self, x):
+        coefficients, knots = [], []
+        for i in range(self.num_params):
+            coefficients.append(self.__getattr__("c{:d}".format(i)).value)
+            knots.append(self.__getattr__("t{:d}".format(i)).value)
+        return self.__class__.evaluate(x, self.degree, knots, coefficients)
+
+    def __getattr__(self, attr):
+        if self.param_names and attr in self.param_names:
+            return Parameter(attr, default=0.0, model=self)
+        else:
+            return super(BSplineModel, self).__getattr__(attr)
+
+    def __setattr__(self, attr, value):
+        # TODO: Support a means of specifying default values for coefficients
+        # Check for self._ndim first--if it hasn't been defined then the
+        # instance hasn't been initialized yet and self.param_names probably
+        # won't work.
+        # This has to vaguely duplicate the functionality of
+        # Parameter.__set__.
+        # TODO: I wonder if there might be a way around that though...
+        if attr[0] != '_' and self.param_names and attr in self.param_names:
+            param = Parameter(attr, default=0.0, model=self)
+            # This is a little hackish, but we can actually reuse the
+            # Parameter.__set__ method here
+            param.__set__(self, value)
+        else:
+            super(BSplineModel, self).__setattr__(attr, value)
+
+
+#^^^^^^^^^^^^^^^^^
+class Spectrum1DWCSError(Exception):
+    pass
+
+
+class Spectrum1DWCSFITSError(Spectrum1DWCSError):
+    pass
+
+
+class Spectrum1DWCSUnitError(Spectrum1DWCSError):
+    pass
+
+
+class BaseSpectrum1DWCS(Model):
+    """
+    Base class for a Spectrum1D WCS
+    """
+
+    n_inputs = 1
+    n_outputs = 1
+
+    _default_equivalencies = u.spectral()
+
+    def __init__(self, *args, **kwargs):
+        super(BaseSpectrum1DWCS, self).__init__(*args, **kwargs)
+
+    @property
+    def equivalencies(self):
+        """Equivalencies for spectral axes include spectral equivalencies and doppler"""
+        if hasattr(self, '_equivalencies'):
+            return self._equivalencies
+        else:
+            return self._default_equivalencies
+
+    #@equivalencies.setter
+    #def equivalencies(self, equiv):
+    #    u.core._normalize_equivalencies(equiv)
+    #    self._equivalencies = equiv
+
+    @property
+    def unit(self):
+        if self._unit is None:
+            return 1.0
+        else:
+            return self._unit
+
+    @unit.setter
+    def unit(self, value):
+        if value is None:
+            warnings.warn(
+                'Initializing a Spectrum1D WCS with units set to `None` is not recommended')
+            self._unit = None
+        else:
+            self._unit = u.Unit(value)
+
+    def reset_equivalencies(self):
+        """
+        Reset the equivalencies to the defaults (probably u.spectral())
+        """
+        self._equivalencies = self._default_equivalencies
+
+    def add_equivalency(self, new_equiv):
+        """
+        Add a new equivalency
+
+        Parameters
+        ----------
+        new_equiv: list
+            A list of equivalency mappings
+         """
+        u.core._normalize_equivalencies(new_equiv)
+        self._equivalencies += new_equiv
+
+
+class Spectrum1DLookupWCS(BaseSpectrum1DWCS):
+    """
+    A simple lookup table wcs
+
+    Parameters
+    ----------
+
+    lookup_table : ~np.ndarray or ~astropy.units.Quantity
+        lookup table for the array
+    """
+
+    n_inputs = 1
+    n_outputs = 1
+    lookup_table_parameter = Parameter('lookup_table_parameter')
+
+    def __init__(self, lookup_table, unit=None,
+                 lookup_table_interpolation_kind='linear'):
+        super(Spectrum1DLookupWCS, self).__init__(
+            lookup_table_parameter=lookup_table)
+
+        if unit is not None:
+            self.lookup_table_parameter = u.Quantity(lookup_table, unit)
+            self.unit = u.Unit(unit)
+        else:
+            self.lookup_table_parameter = lookup_table
+            self.unit = None
+
+        self.lookup_table_interpolation_kind = lookup_table_interpolation_kind
+
+        #Making sure that 1d transformations are sensible
+        assert self.lookup_table_parameter.value.ndim == 1
+
+        #check that array gives a bijective transformation (that forwards and
+        # backwards transformations are unique)
+        if len(self.lookup_table_parameter.value) != len(
+                np.unique(self.lookup_table_parameter.value)):
+            raise Spectrum1DWCSError(
+                'The lookup table does not describe a unique transformation')
+        self.pixel_index = np.arange(len(self.lookup_table_parameter.value))
+
+    def evaluate(self, pixel_indices, lookup_table):
+        lookup_table = np.squeeze(lookup_table)
+        pixel_index = np.arange(len(lookup_table))
+        if self.lookup_table_interpolation_kind == 'linear':
+            return np.interp(pixel_indices, pixel_index, lookup_table,
+                             left=np.nan, right=np.nan) * self.unit
+        else:
+            raise NotImplementedError(
+                'Interpolation type {0} is not implemented'.format(
+                    self.lookup_table_interpolation_kindkind))
+
+    def invert(self, dispersion_values):
+        if self.lookup_table_interpolation_kind == 'linear':
+            return np.interp(dispersion_values,
+                             self.lookup_table_parameter.value,
+                             self.pixel_index, left=np.nan,
+                             right=np.nan)
+        else:
+            raise NotImplementedError(
+                'Interpolation type %s is not implemented' % self.lookup_table_interpolation_kind)
+
+
+class Spectrum1DPolynomialWCS(BaseSpectrum1DWCS, polynomial.Polynomial1D):
+    """
+    WCS for polynomial dispersion. The only added parameter is a unit,
+    otherwise the same as 'astropy.modeling.polynomial.Polynomial1D'
+    """
+    def __init__(self, degree, unit=None, domain=None, window=[-1, 1],
+                 **params):
+        super(Spectrum1DPolynomialWCS, self).__init__(degree, domain=domain,
+                                                      window=window, **params)
+        self.unit = unit
+
+        self.fits_header_writers = {'linear': self._write_fits_header_linear,
+                                    'matrix': self._write_fits_header_matrix}
+
+
+    def evaluate(self, pixel_indices, *coeffs):
+        return super(Spectrum1DPolynomialWCS, self).evaluate(pixel_indices,
+                                                            *coeffs) * self.unit
+
+    def write_fits_header(self, header, spectral_axis=1, method='linear'):
+        self.fits_header_writers[method](header, spectral_axis)
+
+    def _write_fits_header_linear(self, header, spectral_axis=1):
+        header['cdelt{0}'.format(spectral_axis)] = self.c1.value
+        header['crval{0}'.format(spectral_axis)] = self.c0.value
+
+        if self._unit is not None:
+            unit_string = self.unit
+            if isinstance(self.unit, u.UnitBase):
+                if self.unit == u.AA:
+                    unit_string = 'angstroms'
+                else:
+                    unit_string = self.unit.to_string()
+
+            header['cunit{0}'.format(spectral_axis)] = unit_string
+
+    def _write_fits_header_matrix(self, header, spectral_axis=1):
+        header['cd{0}_{1}'.format(spectral_axis, spectral_axis)] = self.c1.value
+        header['crval{0}'.format(spectral_axis)] = self.c0.value
+
+        if self._unit is not None:
+            unit_string = self.unit
+            if isinstance(self.unit, u.UnitBase):
+                if self.unit == u.AA:
+                    unit_string = 'angstroms'
+                else:
+                    unit_string = self.unit.to_string()
+
+            header['cunit{0}'.format(spectral_axis)] = unit_string
+
+
+class Spectrum1DIRAFLegendreWCS(BaseSpectrum1DWCS, polynomial.Legendre1D):
+    """
+    WCS for polynomial dispersion using Legendre polynomials with
+    transformation required for processing IRAF specification described at
+    http://iraf.net/irafdocs/specwcs.php
+    """
+    def __init__(self, order, pmin, pmax, **coefficients):
+        super(Spectrum1DIRAFLegendreWCS, self).__init__(
+            order-1, domain=[pmin, pmax], **coefficients)
+        self.pmin = pmin
+        self.pmax = pmax
+
+    def __call__(self, pixel_indices):
+        transformed = pixel_indices + self.pmin
+        return super(Spectrum1DIRAFLegendreWCS, self).__call__(transformed)
+
+    def get_fits_spec(self):
+        # if abs(self.indexer.step) != 1:
+        #     raise Spectrum1DWCSFITSError("WCS with indexer step greater than 1"
+        #                                  "cannot be written")
+        func_type = 2
+        order = self.degree + 1
+        coefficients = [self.__getattr__('c{0}'.format(i)).value
+                        for i in range(order)]
+        return [func_type, order, self.pmin, self.pmax] + coefficients
+
+class Spectrum1DIRAFChebyshevWCS(BaseSpectrum1DWCS, polynomial.Chebyshev1D):
+    """
+    WCS for polynomial dispersion using Chebyshev polynomials with
+    transformation required for processing IRAF specification described at
+    http://iraf.net/irafdocs/specwcs.php
+
+    See Also
+    --------
+    astropy.modeling.polynomial.Chebyshev1D
+    astropy.modeling.polynomial.Polynomial1D
+    """
+
+    def __init__(self, order, pmin, pmax, **coefficients):
+        super(Spectrum1DIRAFChebyshevWCS, self).__init__(
+            order-1, domain=[pmin, pmax], **coefficients)
+        self.pmin = pmin
+        self.pmax = pmax
+
+    def __call__(self, pixel_indices):
+        transformed = pixel_indices + self.pmin
+        return super(Spectrum1DIRAFChebyshevWCS, self).__call__(transformed)
+
+    def get_fits_spec(self):
+        # if abs(self.indexer.step) != 1:
+        #     raise Spectrum1DWCSFITSError("WCS with indexer step greater than 1"
+        #                                  "cannot be written")
+        func_type = 1
+        order = self.degree + 1
+        coefficients = [self.__getattr__('c{0}'.format(i)).value
+                        for i in range(order)]
+        return [func_type, order, self.pmin, self.pmax] + coefficients
+
+class Spectrum1DIRAFBSplineWCS(BaseSpectrum1DWCS, BSplineModel):
+    """
+    WCS for polynomial dispersion using BSpline functions with transformation
+    required for processing IRAF specification described at
+    http://iraf.net/irafdocs/specwcs.php
+    """
+
+    def __init__(self, degree, npieces, y, pmin, pmax):
+        from scipy.interpolate import splrep
+        self.npieces = npieces
+        self.y = y
+
+        x = np.arange(npieces + degree)
+        knots, coefficients, _ = splrep(x, y, k=degree)
+        super(Spectrum1DIRAFBSplineWCS, self).__init__(degree, knots,
+                                                       coefficients)
+        self.pmin = pmin
+        self.pmax = pmax
+
+    def __call__(self, pixel_indices):
+        s = (pixel_indices * 1.0 * self.npieces) / (self.pmax - self.pmin)
+        return super(Spectrum1DIRAFBSplineWCS, self).__call__(s)
+
+    def get_fits_spec(self):
+        if self.degree == 1:
+            func_type = 4
+        elif self.degree == 3:
+            func_type = 3
+        else:
+            raise Spectrum1DWCSFITSError("Fits spec undefined for degree = "
+                                         "{0}".format(self.degree))
+        return [func_type, self.npieces, self.pmin, self.pmax] + self.y
+
+
+class WeightedCombinationWCS(Model):
+    """
+    A weighted combination WCS model. This model combines multiple WCS using a
+    weight and a zero point offset. Suppose there are n WCS'es. When called with
+    an input, this WCS returns the following:
+            Sum over i = 1 to n
+                [weight_i * (zero_point_offset_i + WCS_i(input))
+    WCS can be added using the add_wcs method, along with it's weight and zero
+    point offset.
+
+    Parameters
+    -----------
+    wcs_list : list of callable objects, optional
+        The object's wcs_list will be instantiated using wcs from this list,
+        with weight as 1.0, and zero point offset as 0.0
+    """
+
+    def __init__(self, wcs_list=None):
+        self.wcs_list = []
+        if wcs_list is not None:
+            for wcs in wcs_list:
+                self.add_WCS(wcs)
+
+    def add_WCS(self, wcs, weight=1.0, zero_point_offset=0.0):
+        """
+        Add a WCS/function pointer to be evaluated when this WCS is called. The
+        results of calling this WCS on the input will be added to the overall
+        result, after applying the weight and the zero point offset.
+
+        Parameters
+        -----------
+        wcs : callable
+            The WCS to be added
+        weight: float, optional
+            The weight of the WCS in this model
+        zero_point: float, optional
+            The output of the WCS will be offset by this value before being
+            multiplied by the weight
+        """
+        self.wcs_list.append((wcs, weight, zero_point_offset))
+
+    def __call__(self, input):
+        """
+        Applies the WCS'es and functions to the input and returns the
+        weighted sum of all the results
+
+        Parameters
+        -----------
+        input : numpy array
+            The input to the composite WCS
+        """
+        return self.__class__.evaluate(input, self.wcs_list)
+
+    @classmethod
+    def evaluate(cls, input, wcs_list):
+        output = np.zeros(len(input) if hasattr(input, "__len__") else 1)
+        for wcs, weight, zero_point_offset in wcs_list:
+            output += weight * (zero_point_offset + wcs(input))
+        return output
+
+
+
+class CompositeWCS(Model):
+    """
+    A composite WCS model. This model applies multiple WCS in-order to a
+    particular input. Suppose there are 4 WCS'es, When called, this WCS returns
+    the following:
+                        wcs_4(wcs_3(wcs_2(wcs_1(input))))
+    The WCS which is added first is applied first. WCS'es can be added using
+    the add_wcs method.
+
+    Parameters
+    -----------
+    wcs_list : list of callable objects, optional
+        The object's wcs_list will be instantiated using wcs from this list
+    """
+    def __init__(self, wcs_list=None):
+        self.wcs_list = []
+        if wcs_list is not None:
+            for wcs in wcs_list:
+                self.add_WCS(wcs)
+
+    def add_WCS(self, wcs):
+        """
+        Add a WCS/function pointer on top of the current transformation. This
+        will be called after the previous items in the list
+
+        Parameters
+        -----------
+        wcs : callable
+            The WCS to be added
+        """
+        self.wcs_list.append(wcs)
+
+    def __call__(self, input):
+        """
+        Applies the chain of WCS'es and functions to the input and returns the
+        result
+
+        Parameters
+        -----------
+        input : numpy array
+            The input to the composite WCS
+        """
+        return self.__class__.evaluate(input, self.wcs_list)
+
+    @classmethod
+    def evaluate(cls, input, wcs_list):
+        output = input
+        for wcs in wcs_list:
+            output = wcs(output)
+        return output
+
+
+class DopplerShift(Model):
+    """
+    This model applies doppler shift to the input. Instantiates the doppler
+    shift model from the velocity (v). The doppler factor is computed
+    using the following formula:
+                    doppler factor = sqrt((1 + v/c)/(1 - v/c))
+    where c is the speed of light
+    When the model is called on an input, input * doppler_factor is returned.
+    The inverse of this model can also be called, which divides the input by
+    the doppler factor.
+
+    Parameters
+    -----------
+    velocity : float
+        the relative velocity between the observer and the source
+    """
+
+
+    @classmethod
+    def from_redshift(cls, z):
+        """
+        Instantiates the doppler shift model from redshift (z).
+
+        Parameters
+        -----------
+        z : float
+            the redshift
+        """
+        doppler_factor = z + 1
+        return cls.from_doppler_factor(doppler_factor)
+
+    @classmethod
+    def from_doppler_factor(cls, doppler_factor):
+        """
+        Instantiates the doppler shift model from the doppler factor.
+
+        Parameters
+        -----------
+        doppler_factor : float
+            the doppler factor
+        """
+        velocity = constants.c*((doppler_factor**2 - 1)/(doppler_factor**2 + 1))
+        return cls(velocity)
+
+    def __init__(self, velocity):
+        self.velocity = velocity
+
+    def __call__(self, input):
+        """
+        Applies the doppler shift to the input, and returns the result
+
+        Parameters
+        -----------
+        input : numpy array
+            The input to be shifted
+        """
+        return self.__class__.evaluate(input, self.doppler_factor)
+
+    @classmethod
+    def evaluate(cls, input, doppler_factor):
+        return input * doppler_factor
+
+    def inverse(self):
+        """
+        Returns a new Doppler shift model, inverse of this doppler shift model.
+        Basically, it instantiates the new doppler shift model with -velocity.
+        """
+        return DopplerShift(-self.velocity)
+
+    @property
+    def beta(self):
+        return self.velocity / constants.c
+
+    @property
+    def doppler_factor(self):
+        return math.sqrt((1 + self.beta)/(1 - self.beta))
+
+    @property
+    def redshift(self):
+        return self.doppler_factor - 1
+
+
+class MultispecIRAFCompositeWCS(BaseSpectrum1DWCS, CompositeWCS):
+    """
+    A specialized composite WCS model for IRAF FITS multispec specification.
+    This model adds applies doppler adjustment and log (if applicable) to the
+    dispersion WCS. The dispersion WCS may be a linear WCS or a weighted
+    combination WCS. This model stores FITS metadata and also provides a method
+    to generate the  multispec string for the FITS header.
+
+    Parameters
+    -----------
+    dispersion_wcs : Model
+        the wcs that returns the raw dispersion when passed the pixel
+        coordinates. There is no doppler shift applied to this dispersion
+    num_pixels : int
+        the number of valid pixels
+    z : float, optional
+        the redshift, used to determine the doppler shift needed to correct the
+        dispersion. Th default value indictes there is no shift
+    log : bool, optional
+        whether log correction needs to be applied to the dispersion
+    aperture : int, optional
+        the aperture number
+    beam : int, optional
+        the beam number
+    aperture_low : float, optional
+        the lower aperture limit
+    aperture_high : float, optional
+        the higher aperture limit
+    unit: astropy.unit, optional
+        the unit of the dispersion
+    """
+
+    def __init__(self, dispersion_wcs, num_pixels, z=1.0, log=False,
+                 aperture=1, beam=88, aperture_low=0.0, aperture_high=0.0,
+                 unit=None):
+        doppler_wcs = DopplerShift.from_redshift(z).inverse
+        super(MultispecIRAFCompositeWCS, self).__init__([dispersion_wcs,
+                                                         doppler_wcs])
+        self.aperture = aperture
+        self.beam = beam
+        self.num_pixels = num_pixels
+        self.aperture_low = aperture_low
+        self.aperture_high = aperture_high
+        self.unit = unit
+        if log:
+            self.add_WCS(lambda x: 10 ** x)
+
+    def __call__(self, pixel_indices):
+        """
+        Applies the model to the pixel coordinates, to produce the dispersion
+        at those pixels
+
+        Parameters
+        -----------
+        pixel_indices : numpy array
+            the pixel coordinates on which dispersion needs to be computed
+        """
+        dispersion = super(MultispecIRAFCompositeWCS,
+                           self).__call__(pixel_indices)
+        return dispersion * self.unit
+
+    def get_fits_spec(self):
+        """
+        Returns the list of spec parameters that represent this model in the
+        order they are supposed to be stored in FITS files
+        """
+        if len(self.wcs_list) == 3:
+            # we don't need to compute the log of dispersion while writing
+            log_wcs = self.wcs_list.pop()
+            dispersion_type = 1
+        else:
+            log_wcs = None
+            dispersion_type = 0
+        dispersion_wcs, doppler_wcs = self.wcs_list
+        if isinstance(dispersion_wcs, WeightedCombinationWCS):
+            dispersion_type = 2
+        # else dispersion_wcs instance of Spectrum1DPolynomialWCS
+        dispersion = self.__call__(np.arange(self.num_pixels)).value
+        avg_disp_delta = (dispersion[1:] - dispersion[:-1]).mean()
+        z = doppler_wcs.redshift
+        spec = [self.aperture, self.beam, dispersion_type, dispersion[0],
+                avg_disp_delta, self.num_pixels, z,
+                self.aperture_low, self.aperture_high]
+        if dispersion_type == 2:
+            # add the parameters of the functions to the spec string
+            for wcs, weight, zero_point_offset in dispersion_wcs.wcs_list:
+                spec.extend([weight, zero_point_offset])
+                spec.extend(wcs.get_fits_spec())
+        if dispersion_type == 1:
+            # add the log_wcs back
+            self.add_WCS(log_wcs)
+
+        return spec

--- a/aesop/spectra.py
+++ b/aesop/spectra.py
@@ -15,14 +15,12 @@ import astropy.units as u
 import astropy.constants as c
 from astropy.time import Time
 from astropy.stats import mad_std
-from specutils.io import read_fits
 
-from astropy.coordinates.solar_system import get_body_barycentric_posvel
-from astropy.coordinates.matrix_utilities import matrix_product
-from astropy.coordinates.representation import CartesianRepresentation ,UnitSphericalRepresentation
-from astropy.coordinates.builtin_frames import GCRS
-from astropy.coordinates import SkyCoord, solar_system, EarthLocation, ICRS
+from astropy.coordinates.representation import (CartesianRepresentation,
+                                                UnitSphericalRepresentation)
+from astropy.coordinates import SkyCoord, solar_system, EarthLocation
 
+from .legacy_specutils import read_fits_spectrum1d
 from .spectral_type import query_for_T_eff
 from .phoenix import get_phoenix_model_spectrum
 from .masking import get_spectrum_mask
@@ -330,7 +328,7 @@ class EchelleSpectrum(object):
             Path to the FITS file
         """
         spectrum_list = [Spectrum1D.from_specutils(s)
-                         for s in read_fits.read_fits_spectrum1d(path)]
+                         for s in read_fits_spectrum1d(path)]
         header = fits.getheader(path)
 
         name = header.get('OBJNAME', None)

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,7 +1,1 @@
-numpy >= 1.6
-matplotlib
-astropy >= 1.3
-sphinx-automodapi
-scipy
-astroquery
-specutils
+``

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,1 +1,6 @@
-``
+numpy >= 1.6
+matplotlib		
+astropy >= 1.3		
+sphinx-automodapi		
+scipy		
+astroquery

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ package_info['package_data'][PACKAGENAME].extend(c_files)
 # ``setup``, since these are now deprecated. See this link for more details:
 # https://groups.google.com/forum/#!topic/astropy-dev/urYO8ckB2uM
 
-setup(name=PACKAGENAME,
+setup(name='arces',
       version=VERSION,
       description=DESCRIPTION,
       scripts=scripts,

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ package_info['package_data'][PACKAGENAME].extend(c_files)
 # ``setup``, since these are now deprecated. See this link for more details:
 # https://groups.google.com/forum/#!topic/astropy-dev/urYO8ckB2uM
 
-setup(name='arces',
+setup(name=PACKAGENAME,
       version=VERSION,
       description=DESCRIPTION,
       scripts=scripts,


### PR DESCRIPTION
Specutils has undergone a major update, which removes the feature that read in IRAF-processed spectra. This patch embeds a lightweight legacy version of specutils into `aesop` so that we can still use the function that reads IRAF-output FITS spectra. 